### PR TITLE
Fix typo in type specification

### DIFF
--- a/schema-base.lisp
+++ b/schema-base.lisp
@@ -165,7 +165,7 @@
   (not :type <forward-referenced-schema>)
   (items :type <forward-referenced-schema>)
   (title :type string)
-  (additional-properties :type (or booeal <forward-referenced-schema>))
+  (additional-properties :type (or boolean <forward-referenced-schema>))
 
   ;; openapi
   (description :field-name "description" :type string)


### PR DESCRIPTION
`booeal` is most likely of type `boolean`. At least with that change I can parse my OAI specification without compilation error. Unfortunately the underlying specification for the security scheme is not valid. It requires name parameters whereas the "real" json/yaml based specification(not the the markdown version)  allows a different set of parameters: https://github.com/OAI/OpenAPI-Specification/blob/36a3a67264cc1c4f1eff110cea3ebfe679435108/schemas/v3.1/schema.yaml#L770

For example:

```
type: http
scheme: basic
```
constitutes a valid security scheme object, but not according to cl-openapi-parser