### PR TITLE
Allow enum values of any type

### DIFF
--- a/schema-base.lisp
+++ b/schema-base.lisp
@@ -138,7 +138,7 @@
 ;; TODO: キーが足りない&型宣言がない
 (define-schema <json-schema> (fixed-fields-schema openapi-parser/schema/3/interface:<json-schema>)
   (type :type string)
-  (enum :type (trivial-types:proper-list (or boolean string)))
+  (enum :type (trivial-types:proper-list t))
   (const)
   (multiple-of)
   (maximum)


### PR DESCRIPTION
According to `draft-bhutton-json-schema-validation-0{0,1}`:

> 6.1.2.  enum
> [...]
> Elements in the array might be of any type, including null.

This allows parsing https://developers.pipedrive.com/docs/api/v1/openapi.yaml , after stripping off its `securitySchemes` section (because of the second bug mentioned in #2 ).

Thank you for your work!